### PR TITLE
Only retrieve data on a success response

### DIFF
--- a/buienalarm/pybuienalarm.py
+++ b/buienalarm/pybuienalarm.py
@@ -80,11 +80,14 @@ class Buienalarm:
         try:
             resp = requests.get(self.__REQUEST_URL, params=payload)
             LOG.debug(resp.url)
-            data = resp.json()
-            if data["success"] is False:
-                LOG.error(data.get("reason"))
+            if resp.ok:
+                data = resp.json()
+                if data["success"] is False:
+                    LOG.error(data.get("reason"))
+                else:
+                    self.data = data
             else:
-                self.data = data
+                LOG.error("Failed to get a response from Buienalarm. Response code: " + str(resp.status_code))
         except requests.exceptions.RequestException as e:
             LOG.error(e)
 


### PR DESCRIPTION
Improves #5 as we no longer crash on a non 20x status code and significantly lowers the amount of errors in Home Assistant as noted in https://github.com/gieljnssns/buienalarm-sensor-homeassistant/issues/19